### PR TITLE
fix warning about conversion from size_t to int

### DIFF
--- a/list-processes_windows.c
+++ b/list-processes_windows.c
@@ -12,7 +12,7 @@
 #include <windows.h>
 #include <tlhelp32.h>
 
-bool utf16ToUtf8(const wchar_t *source, const size_t size, char *destination)
+bool utf16ToUtf8(const wchar_t *source, const int size, char *destination)
 {
 	if (!WideCharToMultiByte(CP_UTF8, 0, source, -1, destination, size, NULL, NULL)) {
 		printf("WideCharToMultiByte() failed with error %d\n", GetLastError());


### PR DESCRIPTION
As `sizeof` can be evaluated at compile-time, the conversion from `size_t` returned by `sizeof` to `int` can be done safely and is thus not generating a compiler-warning.